### PR TITLE
Fix dylib on OSX

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@
 language: generic
 
 os: osx
-osx_image: beta-xcode6.1
+osx_image: xcode6.4
 
 env:
   global:
@@ -14,18 +14,32 @@ env:
 
 before_install:
     # Remove homebrew.
-    - brew remove --force $(brew list)
-    - brew cleanup -s
-    - rm -rf $(brew --cache)
+    - |
+      echo ""
+      echo "Removing homebrew from Travis CI to avoid conflicts."
+      curl -fsSL https://raw.githubusercontent.com/Homebrew/install/master/uninstall > ~/uninstall_homebrew
+      chmod +x ~/uninstall_homebrew
+      ~/uninstall_homebrew -fq
+      rm ~/uninstall_homebrew
+
 
 install:
+    # Install Miniconda.
     - |
+      echo ""
+      echo "Installing a fresh version of Miniconda."
       MINICONDA_URL="https://repo.continuum.io/miniconda"
       MINICONDA_FILE="Miniconda3-latest-MacOSX-x86_64.sh"
       curl -L -O "${MINICONDA_URL}/${MINICONDA_FILE}"
       bash $MINICONDA_FILE -b
 
+    # Configure conda.
+    - |
+      echo ""
+      echo "Configuring conda."
       source /Users/travis/miniconda3/bin/activate root
+      conda config --remove channels defaults
+      conda config --add channels defaults
       conda config --add channels conda-forge
       conda config --set show_channel_urls true
       conda install --yes --quiet conda-forge-build-setup

--- a/LICENSE
+++ b/LICENSE
@@ -1,5 +1,5 @@
 BSD 3-clause license
-Copyright (c) conda-forge
+Copyright (c) 2015-2017, conda-forge
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without modification, are permitted provided that the following conditions are met:

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ About rpfits
 
 Home: http://www.atnf.csiro.au/computing/software/rpfits.html
 
-Package license: unspecified
+Package license: CSIRO Open Source Software Agreement (GPLv3+)
 
 Feedstock license: BSD 3-Clause
 

--- a/ci_support/run_docker_build.sh
+++ b/ci_support/run_docker_build.sh
@@ -14,7 +14,7 @@ config=$(cat <<CONDARC
 
 channels:
  - conda-forge
- - defaults # As we need conda-build
+ - defaults
 
 conda-build:
  root-dir: /feedstock_root/build_artefacts
@@ -25,8 +25,8 @@ CONDARC
 )
 
 cat << EOF | docker run -i \
-                        -v ${RECIPE_ROOT}:/recipe_root \
-                        -v ${FEEDSTOCK_ROOT}:/feedstock_root \
+                        -v "${RECIPE_ROOT}":/recipe_root \
+                        -v "${FEEDSTOCK_ROOT}":/feedstock_root \
                         -a stdin -a stdout -a stderr \
                         condaforge/linux-anvil \
                         bash || exit $?

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -24,7 +24,6 @@ if [ -n "$OSX_ARCH" ] ; then
     SOEXT=dylib # see other choice; there's a reason we're not using $SHLIB_EXT
     SOFLAGS=(
 	-dynamiclib
-	-static-libgfortran
 	-install_name '@rpath/librpfits.dylib'
 	-compatibility_version 1.0.0
 	-current_version 1.0.0
@@ -33,6 +32,15 @@ if [ -n "$OSX_ARCH" ] ; then
     EXEFLAGS=(
 	-dynamic
     )
+
+    # See pgplot-feedstock:recipe/build.sh for an explanation of what's going
+    # on here. A bad path in the `gcc` package propagates into our dylib
+    # without this workaround.
+    for name in gcc_ext.10.4 gcc_ext.10.5 ; do
+        badlib="$PREFIX/lib/lib${name}.dylib"
+        rm -f "$badlib"
+        ln -s "libgcc_s.1.dylib" "$badlib"
+    done
 else
     SOEXT=so.0 # note: the ".0" makes this not the same as $SHLIB_EXT
     SOFLAGS=(

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,14 +12,14 @@ source:
   sha256: {{ sha256 }}
 
 build:
-  number: 0
+  number: 1
   detect_binary_files_with_prefix: true
   skip: true  # [win]
 
 requirements:
   build:
     - gcc  # [osx]
-    - libgfortran  # [unix]
+    - libgfortran  # [linux]
     - toolchain
   run:
     - libgfortran  # [unix]


### PR DESCRIPTION
As per pgplot-feedstock#1, Fortran dylibs on OSX can be generated with a bad path that messes things up. This works around the problem.

I also switch the source URL back to the ATNF FTP server since conda-build has learned how to deal with multi-line FTP server responses, which the ATNF server produces.